### PR TITLE
TKNECO-30: Skopeo-Copy Task

### DIFF
--- a/templates/task-sc.yaml
+++ b/templates/task-sc.yaml
@@ -2,53 +2,53 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-    name: skopeo-copy
-    labels:
-        app.kubernetes.io/version: 0.0.1
+  name: skopeo-copy
+  labels:
+    app.kubernetes.io/version: 0.0.1
 spec:
-    description: | 
-        Skopeo is a command line tool for working with remote image registries. 
-        The copy command will take care of copying the image from internal.registry to production.registry. If your production registry requires credentials to login in order to push the image, skopeo can handle that as well.
-    params:
-        -   name: SOURCE_REGISTRY
-            type: string
-            description: |
-                Source Registry URL
-        -   name: DESTINATION_REGISTRY
-            type: string
-            description: |
-                Destination Registry URL
-        -   name: SOURCE_AUTH_USERNAME
-            type: string
-            description: |
-                Source Registry Username for authentication
-        -   name: SOURCE_AUTH_PASSWORD
-            type: string
-            description: |
-                Source Registry Password for authentication
-        -   name: DESTINATION_AUTH_USERNAME
-            type: string
-            description: |
-                Destination Registry Username for authentication
-        -   name: DESTINATION_AUTH_PASSWORD
-            type: string
-            description: |
-                Destination Registry Password for authentication
-    steps:
-    -   name: login-src
-        image: quay.io/skopeo/stable:latest
-        script: |
-            skopeo login docker.io -u=$(params.SOURCE_AUTH_USERNAME) -p=$(params.SOURCE_AUTH_PASSWORD)
-    -   name: login-dest
-        image: quay.io/skopeo/stable:latest
-        script: |
-            skopeo login docker.io -u=$(params.DESTINATION_AUTH_USERNAME) -p=$(params.DESTINATION_AUTH_PASSWORD)
-    -   name: copy
-        image: quay.io/skopeo/stable:latest
-        script: |
-            skopeo copy --src-creds $(params.SOURCE_AUTH_USERNAME):$(params.SOURCE_AUTH_PASSWORD) \
-            docker://$(params.SOURCE_REGISTRY) --dest-creds $(params.DESTINATION_AUTH_USERNAME):$(params.DESTINATION_AUTH_PASSWORD) \
-            docker://$(params.DESTINATION_REGISTRY)
-            echo "Copied"
-
+  description: | 
+    Skopeo is a command line tool for working with remote image registries. 
+    The copy command will take care of copying the image from internal.registry 
+    to production.registry. If your production registry requires credentials to 
+    login in order to push the image, skopeo can handle that as well.
+  params:
+    - name: SOURCE_REGISTRY
+      type: string
+      description: |
+        Source Registry URL
+    - name: DESTINATION_REGISTRY
+      type: string
+      description: |
+        Destination Registry URL
+    - name: SOURCE_AUTH_USERNAME
+      type: string
+      description: |
+        Source Registry Username for authentication
+    - name: SOURCE_AUTH_PASSWORD
+      type: string
+      description: |
+        Source Registry Password for authentication
+    - name: DESTINATION_AUTH_USERNAME
+      type: string
+      description: |
+        Destination Registry Username for authentication
+    - name: DESTINATION_AUTH_PASSWORD
+      type: string
+      description: |
+        Destination Registry Password for authentication
+  steps:
+    - name: login-src
+      image: quay.io/skopeo/stable:latest
+      script: |
+        skopeo login docker.io -u=$(params.SOURCE_AUTH_USERNAME) -p=$(params.SOURCE_AUTH_PASSWORD)
+    - name: login-dest
+      image: quay.io/skopeo/stable:latest
+      script: |
+        skopeo login docker.io -u=$(params.DESTINATION_AUTH_USERNAME) -p=$(params.DESTINATION_AUTH_PASSWORD)
+    - name: copy
+      image: quay.io/skopeo/stable:latest
+      script: |
+        skopeo copy --src-creds $(params.SOURCE_AUTH_USERNAME):$(params.SOURCE_AUTH_PASSWORD) \
+        docker://$(params.SOURCE_REGISTRY) --dest-creds $(params.DESTINATION_AUTH_USERNAME):$(params.DESTINATION_AUTH_PASSWORD) \
+        docker://$(params.DESTINATION_REGISTRY)
 

--- a/templates/task-sc.yaml
+++ b/templates/task-sc.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+    name: skopeo-copy
+    labels:
+        app.kubernetes.io/version: 0.0.1
+spec:
+    description: | 
+        Skopeo is a command line tool for working with remote image registries. 
+        The copy command will take care of copying the image from internal.registry to production.registry. If your production registry requires credentials to login in order to push the image, skopeo can handle that as well.
+    params:
+        -   name: SOURCE_REGISTRY
+            type: string
+            description: |
+                Source Registry URL
+        -   name: DESTINATION_REGISTRY
+            type: string
+            description: |
+                Destination Registry URL
+        -   name: SOURCE_AUTH_USERNAME
+            type: string
+            description: |
+                Source Registry Username for authentication
+        -   name: SOURCE_AUTH_PASSWORD
+            type: string
+            description: |
+                Source Registry Password for authentication
+        -   name: DESTINATION_AUTH_USERNAME
+            type: string
+            description: |
+                Destination Registry Username for authentication
+        -   name: DESTINATION_AUTH_PASSWORD
+            type: string
+            description: |
+                Destination Registry Password for authentication
+    steps:
+    -   name: login-src
+        image: quay.io/skopeo/stable:latest
+        script: |
+            skopeo login docker.io -u=$(params.SOURCE_AUTH_USERNAME) -p=$(params.SOURCE_AUTH_PASSWORD)
+    -   name: login-dest
+        image: quay.io/skopeo/stable:latest
+        script: |
+            skopeo login docker.io -u=$(params.DESTINATION_AUTH_USERNAME) -p=$(params.DESTINATION_AUTH_PASSWORD)
+    -   name: copy
+        image: quay.io/skopeo/stable:latest
+        script: |
+            skopeo copy --src-creds $(params.SOURCE_AUTH_USERNAME):$(params.SOURCE_AUTH_PASSWORD) \
+            docker://$(params.SOURCE_REGISTRY) --dest-creds $(params.DESTINATION_AUTH_USERNAME):$(params.DESTINATION_AUTH_PASSWORD) \
+            docker://$(params.DESTINATION_REGISTRY)
+            echo "Copied"
+
+


### PR DESCRIPTION
Created a draft template for Skopeo-Copy Task which takes input parameters (Following ALL_CAPS scheme)  as:

- `SOURCE_REGISTRY` - for storing source registry URL
- `DESTINATION_REGISTRY` -  for storing source registry URL
- `SOURCE_AUTH_USERNAME` - for storing source registry username for authentication purpose
- `SOURCE_AUTH_PASSWORD` - for storing source registry password
- `DESTINATION_AUTH_USERNAME` - for storing destination registry username
- `DESTINATION_AUTH_PASSWORD` - for storing destination registry password

Currently the task comprises of 3 steps:

- Authentication of Source directory
- Authentication of Destination directory
- Skopeo-Copy task which basically runs the script for copying the image from one registry to another

Upon testing the task by TaskRun, I was able to copy image from source to destination. 

But it is just a draft implementation, I guess the way to proceed with it ahead will be:

- Instead of writing the steps scripts manually in the `task-sc.yaml` we have separate bash scripts doing the same
- Will we be requiring `workspaces` for this task since skopeo-copy doesn't involve storing image locally? Also how will the authentication take place like in which mode we will get the credentials?
-  Bundling it in Helm Package
- Create Integration tests and e2e test and verify it locally using bats.

Let me know your thoughts and how I should proceed with the PR.