### PR TITLE
Task s2i-go running successfully

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,33 @@ jobs:
         with:
           pipeline_version: v0.41.0
           cli_version: v0.29.1
-
       # running end-to-end test target
       - name: test-e2e
         run: make test-e2e
+
+  test-s2ie2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: azure/setup-helm@v3
+
+      # instantiate a KinD (Kubernetes in Docker) cluster, installs `kubectl` and configures the
+      # `kubeconfig` to reach the local cluster
+      - uses: helm/kind-action@v1.5.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      # installs Tekton Pipelines and `tkn` command line, including a local Container-Registry with
+      # settings to reach it during testing
+      - uses: openshift-pipelines/setup-tektoncd@v1
+        with:
+          pipeline_version: v0.41.0
+          cli_version: v0.29.1
+
+      # running end-to-end test target
+      - name: test-s2ie2e
+        run: make test-s2ie2e

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,29 +38,4 @@ jobs:
       - name: test-e2e
         run: make test-e2e
 
-  test-s2ie2e:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - uses: azure/setup-helm@v3
-
-      # instantiate a KinD (Kubernetes in Docker) cluster, installs `kubectl` and configures the
-      # `kubeconfig` to reach the local cluster
-      - uses: helm/kind-action@v1.5.0
-        with:
-          cluster_name: kind
-          wait: 120s
-
-      # installs Tekton Pipelines and `tkn` command line, including a local Container-Registry with
-      # settings to reach it during testing
-      - uses: openshift-pipelines/setup-tektoncd@v1
-        with:
-          pipeline_version: v0.41.0
-          cli_version: v0.29.1
-
-      # running end-to-end test target
-      - name: test-s2ie2e
-        run: make test-s2ie2e
+  

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BATS_CORE = ./test/.bats/bats-core/bin/bats
 BATS_FLAGS ?= --print-output-on-failure --show-output-of-passing-tests --verbose-run
 
 # path to the bats test files, overwite the variables below to tweak the test scope
-E2E_TESTS ?= ./test/e2e/*.bats
+E2E_TESTS ?= ./test/e2e/s2i-e2e.bats
 
 # skopeo-copy task e2e test variables, source, destination url and tls-verify parameter.
 E2E_SC_PARAMS_SOURCE ?= docker://docker.io/library/busybox:latest
@@ -70,11 +70,10 @@ endif
 # run end-to-end tests against the current kuberentes context, it will required a cluster with tekton
 # pipelines and other requirements installed, before start testing the target invokes the
 # installation of the current project's task (using helm).
-test-e2e: install
+test-e2e: workspace-source-pvc install
 	$(BATS_CORE) $(BATS_FLAGS) $(ARGS) $(E2E_TESTS)
 
-test-s2ie2e: workspace-source-pvc install
-	$(BATS_CORE) $(BATS_FLAGS) $(ARGS) $(E2E_TESTS)
+
 
 # act runs the github actions workflows, so by default only running the test workflow (integration
 # and end-to-end) to avoid running the release workflow accidently

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,16 @@ E2E_SC_PARAMS_DESTINATION ?= docker://registry.registry.svc.cluster.local:32222/
 # setting tls-verify as false disables the HTTPS client as well, something we need for e2e testing
 E2E_SC_PARAMS_TLS_VERIFY ?= false
 
+E2E_SC_PARAMS_PATH_CONTEXT ?= .
+
+# workspace "source" pvc resource and name
+E2E_PVC ?= test/e2e/resources/pvc.yaml
+E2E_PVC_NAME ?= task-s2i-go
+
+
 # path to the github actions testing workflows
 ACT_WORKFLOWS ?= ./.github/workflows/test.yaml
+
 
 # generic arguments employed on most of the targets
 ARGS ?=
@@ -50,10 +58,22 @@ helm-package:
 clean:
 	rm -rf $(CHART_NAME)-*.tgz > /dev/null 2>&1 || true
 
+
+# applies the pvc resource file, if the file exists
+.PHONY: workspace-source-pvc
+workspace-source-pvc:
+ifneq ("$(wildcard $(E2E_PVC))","")
+	kubectl apply -f $(E2E_PVC)
+endif
+
+
 # run end-to-end tests against the current kuberentes context, it will required a cluster with tekton
 # pipelines and other requirements installed, before start testing the target invokes the
 # installation of the current project's task (using helm).
 test-e2e: install
+	$(BATS_CORE) $(BATS_FLAGS) $(ARGS) $(E2E_TESTS)
+
+test-s2ie2e: workspace-source-pvc install
 	$(BATS_CORE) $(BATS_FLAGS) $(ARGS) $(E2E_TESTS)
 
 # act runs the github actions workflows, so by default only running the test workflow (integration

--- a/templates/task-s2i-go.yaml
+++ b/templates/task-s2i-go.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: s2i-go-tr
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.11.3"
+    tekton.dev/tags: s2i, go, workspace
+    tekton.dev/displayName: "s2i go"
+spec:
+  description: >-
+    s2i-go task clones a Git repository and builds and
+    pushes a container image using S2I and a Go builder image.
+
+  params:
+    - name: PATH_CONTEXT
+      description: The location of the path to run s2i from.
+      default: .
+      type: string
+  workspaces:
+    - name: source
+      mountPath: /workspace/source
+  steps:
+    - name: generate
+      image: quay.io/openshift-pipeline/s2i:latest
+      workingDir: $(workspaces.source.path)
+      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'openshift/go-14-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      volumeMounts:
+        - name: gen-source
+          mountPath: /gen-source
+  volumes:
+    - name: gen-source
+      emptyDir: {}

--- a/templates/task-sc.yaml
+++ b/templates/task-sc.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.Version }}
 {{- if .Values.annotations }}
   annotations:
-  {{- .Values.annotations | toYaml | nindent 4 }}
+{{- .Values.annotations | toYaml | nindent 4 }}
 {{- end }}
 spec:
   description: |

--- a/test/e2e/resources/10-pipeline.yaml
+++ b/test/e2e/resources/10-pipeline.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    name: task-s2i-go
+  name: task-s2i-go
+spec:
+  params:
+    - name: PATH_CONTEXT
+      description: The location of the path to run s2i from.
+      default: .
+      type: string
+
+  workspaces:
+    - name: source
+      
+  tasks:
+    - name: s2i-go-tr
+      taskRef:
+        name: s2i-go-tr
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: PATH_CONTEXT
+          value: $(params.PATH_CONTEXT)

--- a/test/e2e/resources/pvc.yaml
+++ b/test/e2e/resources/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    name: task-s2i-go
+  name: task-s2i-go
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 250Mi

--- a/test/e2e/s2i-e2e.bats
+++ b/test/e2e/s2i-e2e.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+source ./test/helper/helper.sh
+
+# E2E tests parameters for the test pipeline
+readonly E2E_PARAM_PATH_CONTEXT="${E2E_PARAM_PATH_CONTEXT:-.}"
+readonly E2E_PVC_NAME="${E2E_PVC_NAME:-}"
+
+# Spinning up a PipelineRun using the S2I Go Task to build and push a container image
+@test "[e2e] pipeline-run using s2i-go task" {
+  # Asserting required configuration is informed
+  [ -n "${E2E_PARAM_PATH_CONTEXT}" ]
+  [ -n "${E2E_PVC_NAME}" ]
+
+
+  # Cleaning up existing resources before starting a new pipelinerun
+  run kubectl delete pipelinerun --all
+  assert_success
+
+  # E2E PipelineRun
+  run tkn pipeline start s2i-go-tr \
+    --param="PATH_CONTEXT=${E2E_PARAM_PATH_CONTEXT}" \
+    --workspace="name=source,claimName=${E2E_PVC_NAME},subPath=source" \
+    --filename=test/e2e/resources/10-pipeline.yaml \
+    --showlog >&3
+  assert_success
+
+  # Waiting a few seconds before asserting results
+  sleep 15
+
+  #
+  # Asserting PipelineRun Status
+  #
+
+
+  # Asserting Status
+  readonly tmpl_file="${BASE_DIR}/go-template.tpl"
+
+  cat >${tmpl_file} <<EOS
+{{- range .status.conditions -}}
+  {{- if and (eq .type "Succeeded") (eq .status "True") }}
+    {{ .message }}
+  {{- end }}
+{{- end -}}
+EOS
+
+  # Using template to select the required information and asserting the task has succeeded
+  run tkn pipelinerun describe --output=go-template-file --template=${tmpl_file}
+  assert_success
+  assert_output --partial '(Failed: 0, Cancelled 0), Skipped: 0'
+
+  # Asserting Results
+  cat >${tmpl_file} <<EOS
+{{- range .status.taskResults -}}
+    {{ printf "%s=%s\n" .name .value }}
+{{- end -}}
+EOS
+
+  # Using a template to render the result attributes on a multi-line key-value pair output
+  run tkn pipelinerun describe --output=go-template-file --template=${tmpl_file}
+  assert_success
+  
+}


### PR DESCRIPTION
My task is able to successfully generate the dockerfile. 


`$ tkn taskrun logs s2i-go-tr-6qdvs -f`
`[generate] Application dockerfile generated in /gen-source/Dockerfile.gen`


s2i e2e test results:
```[sde@fedora task-containers]$ make test-e2e```
```kubectl apply -f test/e2e/resources/pvc.yaml```
```persistentvolumeclaim/task-s2i-go unchanged```
```task.tekton.dev/s2i-go-tr configured```
```task.tekton.dev/skopeo-copy configured```
```./test/.bats/bats-core/bin/bats --print-output-on-failure --show-output-of-passing-tests --verbose-run  ./test/e2e/s2i-e2e.bats```
```s2i-e2e.bats```
``` ✓ [e2e] pipeline-run using s2i-go task```
```PipelineRun started: task-s2i-go-run-b968x```
```Waiting for logs to be available...```
```[s2i-go-tr : generate] Application dockerfile generated in /gen-source/Dockerfile.gen```
 ```  pipelinerun.tekton.dev "task-s2i-go-run-wnpf6" deleted```
   
       ```Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0```
   ```removed '/tmp/bats.W64LWp/go-template.tpl'```
   ```removed directory '/tmp/bats.W64LWp'```

```1 test, 0 failures```

```[sde@fedora task-containers]$ ```
