### PR TITLE
chore: Release Workflow Trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,8 @@
 name: release
 
+# should only run when manually dispatched
 on:
-  push:
-    tags:
-      - "*"
+  workflow_dispatch: {}
 
 jobs:
   release:


### PR DESCRIPTION
Should only run when dispatched using the web interface.