### PR TITLE
Release action through manual trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,7 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "*"
+  workflow_dispatch: {}
 
 jobs:
   release:
@@ -14,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: otaviof/release-tekton-task@main
+      - uses: openshift-pipelines/release-tektoncd-task@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With reference to #43 I have updated the release task to be used too. Now it will run https://github.com/openshift-pipelines/release-tektoncd-task.
