### PR TITLE
helm-fan-out script to prepare a release.

### DIFF
--- a/scripts/helm-fan-out.sh
+++ b/scripts/helm-fan-out.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Based on https://github.com/helm/helm/issues/4680#issuecomment-1152289297
+# helm-fan-out
+
+if [ -z "$1" ]; then
+    echo "Please provide an output directory"
+    exit 1
+fi
+
+awk -vout="$1" -F": " '
+  $0~/^# Source: / {
+    file=out"/"$2;
+    if (!(file in filemap)) {
+      filemap[file] = 1
+      print "Creating "file;
+      system ("mkdir -p $(dirname "file")");
+    }
+    print "---" >> file;
+  }
+  $0!~/^# Source: / {
+    if ($0!~/^---$/) {
+      if (file) {
+        print $0 >> file;
+      }
+    }
+  }'


### PR DESCRIPTION
Each file need to be on its own file to be released (and taken into
account but `catalog-cd release`. This adds a script to do that, in
preparation of a "make release" target.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
