### PR TITLE
TKNECO-94: Release Payload

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,8 +32,7 @@ jobs:
       # settings to reach it during testing
       - uses: openshift-pipelines/setup-tektoncd@v1
         with:
-          pipeline_version: v0.41.0
-          cli_version: v0.29.1
+          pipeline_version: v0.41.3
 
       # running end-to-end test target
       - name: test-e2e

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: task-containers
 description: Contains the Tekton Tasks to manage container images
 type: application
-version: 0.1.0
+version: 0.1.1


### PR DESCRIPTION
Creating the `release.tar.gz` from the `${RELEASE_DIR}` in order to capture the correct relative resource file locations.