### PR TITLE
Update bash, skopeo, buildah and s2i images

### DIFF
--- a/test/e2e/e2e-buildah.bats
+++ b/test/e2e/e2e-buildah.bats
@@ -12,6 +12,15 @@ declare -rx E2E_BUILDAH_PARAMS_IMAGE="${E2E_BUILDAH_PARAMS_IMAGE:-}"
     [ -n "${E2E_BUILDAH_PARAMS_IMAGE}" ]
     [ -n "${E2E_PARAMS_TLS_VERIFY}" ]
 
+
+    kubectl delete secret regcred || true
+    run kubectl create secret generic regcred \
+        --from-file=.dockerconfigjson=$HOME/.docker/config.json \
+        --type=kubernetes.io/dockerconfigjson
+    assert_success
+    run kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+    assert_success
+
     # cleaning up all the existing resources before starting a new taskrun, the test assertion
     # will describe the objects on the current namespace
     run kubectl delete taskrun --all

--- a/test/e2e/e2e-skopeo-copy.bats
+++ b/test/e2e/e2e-skopeo-copy.bats
@@ -17,6 +17,15 @@ declare -rx E2E_SC_PARAMS_DESTINATION="${E2E_SC_PARAMS_DESTINATION:-}"
     run kubectl delete taskrun --all
     assert_success
 
+
+    kubectl delete secret regcred || true
+    run kubectl create secret generic regcred \
+        --from-file=.dockerconfigjson=$HOME/.docker/config.json \
+        --type=kubernetes.io/dockerconfigjson
+    assert_success
+    run kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+    assert_success
+
     #
     # E2E TaskRun
     #

--- a/test/e2e/s2i-e2e.bats
+++ b/test/e2e/s2i-e2e.bats
@@ -68,6 +68,14 @@ EOF
     run kubectl apply --kustomize ${BASE_DIR}
     assert_success
 
+    kubectl delete secret regcred || true
+    run kubectl create secret generic regcred \
+        --from-file=.dockerconfigjson=$HOME/.docker/config.json \
+        --type=kubernetes.io/dockerconfigjson
+    assert_success
+    run kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+    assert_success
+
     tkn pipeline start task-s2i-${E2E_S2I_LANGUAGE} \
         --param="URL=${E2E_S2I_PARAMS_URL}" \
         --param="IMAGE_SCRIPTS_URL=${E2E_S2I_IMAGE_SCRIPTS_URL}" \

--- a/values.yaml
+++ b/values.yaml
@@ -1,10 +1,10 @@
 ---
 # task steps container images
 images:
-  bash: registry.access.redhat.com/ubi8-minimal:latest
-  skopeo: quay.io/skopeo/stable:latest
-  buildah: registry.access.redhat.com/ubi8/buildah:latest
-  s2i: quay.io/openshift-pipeline/s2i:nightly
+  bash: registry.access.redhat.com/ubi8-minimal:8.8
+  skopeo: registry.access.redhat.com/ubi8/skopeo:8.8
+  buildah: registry.access.redhat.com/ubi8/buildah:8.8
+  s2i: registry.access.redhat.com/source-to-image/source-to-image-rhel8:v1.3.9-6
 
 # source-to-image builder images, each language represents a distinct ecosystem the builder supports,
 # sometimes it includes a specific version


### PR DESCRIPTION
- bash: switch to ubi8-minimal
- buildah: use 8.8 instead of latest
- skopeo: use 8.8 instead of quay+latest
- s2i: use redhat support image 1.3.9