### PR TITLE
Merge upstream buildan 0.7 and 0.8 changes

### DIFF
--- a/scripts/buildah-bud.sh
+++ b/scripts/buildah-bud.sh
@@ -34,6 +34,12 @@ phase "Inspecting context '${PARAMS_CONTEXT}'"
 [[ ! -d "${PARAMS_CONTEXT}" ]] &&
     fail "CONTEXT param is not found at '${PARAMS_CONTEXT}', on source workspace"
 
+phase "Building build args"
+BUILD_ARGS=()
+for buildarg in "$@"; do
+    BUILD_ARGS+=("--build-arg=$buildarg")
+done
+
 # Handle optional dockerconfig secret
 if [[ "${WORKSPACES_DOCKERCONFIG_BOUND}" == "true" ]]; then
 
@@ -73,10 +79,10 @@ phase "Building '${PARAMS_IMAGE}' based on '${DOCKERFILE_FULL}'"
 
 _buildah bud ${PARAMS_BUILD_EXTRA_ARGS} \
     $ENTITLEMENT_VOLUME \
-    --no-cache \
+    "${BUILD_ARGS[@]}" \
     --file="${DOCKERFILE_FULL}" \
     --tag="${PARAMS_IMAGE}" \
-    ${PARAMS_CONTEXT}
+    "${PARAMS_CONTEXT}"
 
 if [[ "${PARAMS_SKIP_PUSH}" == "true" ]]; then
     phase "Skipping pushing '${PARAMS_IMAGE}' to the container registry!"
@@ -98,8 +104,8 @@ declare -r digest_file="/tmp/buildah-digest.txt"
 
 _buildah push ${PARAMS_PUSH_EXTRA_ARGS} \
     --digestfile="${digest_file}" \
-    ${PARAMS_IMAGE} \
-    docker://${PARAMS_IMAGE}
+    "${PARAMS_IMAGE}" \
+    "docker://${PARAMS_IMAGE}"
 
 #
 # Results

--- a/templates/task-buildah.yaml
+++ b/templates/task-buildah.yaml
@@ -44,6 +44,12 @@ spec:
       default: ./Dockerfile
       description: |
         Path to the `Dockerfile` (or `Containerfile`) relative to the `source` workspace.
+    - name: BUILD_ARGS
+      type: array
+      default:
+        - ""
+      description: |
+        Dockerfile build arguments, array of key=value
 
 {{- include "params_buildah_common" . | nindent 4 }}
 {{- include "params_common" . | nindent 4 }}
@@ -81,6 +87,8 @@ spec:
     - name: build
       image: {{ .Values.images.buildah }}
       workingDir: /workspace/source
+      args:
+        - $(params.BUILD_ARGS[*])
       command:
         - /scripts/buildah-bud.sh
       securityContext:


### PR DESCRIPTION
I raised a PR on the operator to update the ClusterTask but have been told that is deprecated and to update here - https://github.com/tektoncd/operator/pull/2253

This PR ports changes from upstream catalog buildah 0.8 https://github.com/tektoncd/catalog/pull/1282 and 0.7 https://github.com/tektoncd/catalog/pull/1230

It looks as if this Task is missing a PR from a long time ago to do everything in one step, to avoid excessive memory requirements - https://github.com/tektoncd/operator/pull/904 - should this be raised as a separate PR?