### PR TITLE
Removed extraneous load-scripts step

### DIFF
--- a/templates/load-scripts.tpl
+++ b/templates/load-scripts.tpl
@@ -5,24 +5,22 @@
 */ -}}
 
 {{- define "load_scripts" -}}
-  {{- $global := index . 0 -}}
-- name: load-scripts
-  image: {{ $global.Values.images.bash }}
-  workingDir: /scripts
-  script: |
-    set -e
-  {{- range $i, $prefix := . -}}
-    {{- if gt $i 0 }}
-      {{- range $path, $content := $global.Files.Glob "scripts/*.sh" }}
-        {{- $name := trimPrefix "scripts/" $path }}
-        {{- if or ( hasPrefix $prefix $name ) ( hasPrefix "common" $name ) }}
-    printf '%s' "{{ $content | toString | b64enc }}" |base64 -d >{{ $name }}
-        {{- end }}
-      {{- end }}
-    chmod +x {{ $prefix }}*.sh
+{{- $global := index . 0 -}}
+set -e
+{{- range $i, $prefix := index . 1 -}}
+  {{- range $path, $content := $global.Files.Glob "scripts/*.sh" }}
+    {{- $name := trimPrefix "scripts/" $path }}
+echo "/scripts/{{ $name }}"
+    {{- if or ( hasPrefix $prefix $name ) ( hasPrefix "common" $name ) }}
+printf '%s' "{{ $content | toString | b64enc }}" |base64 -d >"/scripts/{{ $name }}"
     {{- end }}
   {{- end }}
-  volumeMounts:
-    - name: scripts-dir
-      mountPath: /scripts
+ls /scripts/{{ $prefix }}*.sh;
+chmod +x /scripts/{{ $prefix }}*.sh;
+{{- end }}
+
+{{- range $i, $script := index . 2 -}}
+echo "Running Script {{ $script }}";
+  {{ $script }};
+{{- end }}
 {{- end -}}

--- a/templates/spec-s2i.tpl
+++ b/templates/spec-s2i.tpl
@@ -69,16 +69,14 @@ stepTemplate:
 {{- include "environment" ( list $variables ) | nindent 4 }}
 
 steps:
-{{- include "load_scripts" ( list . "buildah-" "s2i-" ) | nindent 2 }}
-
   - name: s2i-generate
     image: {{ .Values.images.s2i }}
     workingDir: $(workspaces.source.path)
     env:
       - name: S2I_BUILDER_IMAGE
         value: "{{ $s2iBuilderImage }}:$(params.VERSION)"
-    command:
-      - /scripts/s2i-generate.sh
+    script: |
+{{- include "load_scripts" ( list . ( list "buildah-" "s2i-" ) ( list "/scripts/s2i-generate.sh" ) ) | nindent 6 }}
     args:
       - "$(params.ENV_VARS[*])"
     securityContext:

--- a/templates/task-buildah.yaml
+++ b/templates/task-buildah.yaml
@@ -82,15 +82,13 @@ spec:
 {{- include "environment" ( list $variables ) | nindent 6 }}
 
   steps:
-{{- include "load_scripts" ( list . "buildah-" ) | nindent 4 }}
-
     - name: build
       image: {{ .Values.images.buildah }}
-      workingDir: /workspace/source
+      workingDir: $(workspaces.source.path)
       args:
         - $(params.BUILD_ARGS[*])
-      command:
-        - /scripts/buildah-bud.sh
+      script: |
+{{- include "load_scripts" ( list . ( list "buildah-" ) ( list "/scripts/buildah-bud.sh" ) ) | nindent 8 }}
       securityContext:
         capabilities:
           add: ["SETFCAP"]

--- a/templates/task-skopeo-copy.yaml
+++ b/templates/task-skopeo-copy.yaml
@@ -78,20 +78,10 @@ spec:
 {{- include "environment" ( list $variables ) | nindent 6 }}
 
   steps:
-{{- include "load_scripts" ( list . "skopeo-" ) | nindent 4 }}
-
     - name: skopeo-copy
       image: {{ .Values.images.skopeo }}
-      command:
-        - /scripts/skopeo-copy.sh
-      volumeMounts:
-        - name: scripts-dir
-          mountPath: /scripts
-
-    - name: skopeo-results
-      image: {{ .Values.images.skopeo }}
-      command:
-        - /scripts/skopeo-results.sh
+      script: |
+{{- include "load_scripts" ( list . ( list "skopeo-" ) ( list "/scripts/skopeo-copy.sh" "/scripts/skopeo-results.sh" ) ) | nindent 8 }}
       volumeMounts:
         - name: scripts-dir
           mountPath: /scripts


### PR DESCRIPTION
Added support to run scripts in the load-scripts.tpl.
Converted load-scripts.tpl to make a template for script instead of a step template. 
Reason: load-scripts added an extra step which due to the way its run in customer's clusters increased its overhead.