### PR TITLE
Resolved docker credentials issue for skopeo-copy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: task-containers
 description: Contains the Tekton Tasks to manage container images
 type: application
-version: 0.3.3
+version: 0.4.0

--- a/scripts/skopeo-common.sh
+++ b/scripts/skopeo-common.sh
@@ -29,7 +29,7 @@ exported_or_fail \
 
 declare -x REGISTRY_AUTH_FILE=""
 
-docker_config="${HOME}/.docker/config.json"
+docker_config="/tekton/home/.docker/config.json"
 if [[ -f "${docker_config}" ]]; then
     phase "Setting REGISTRY_AUTH_FILE to '${docker_config}'"
     REGISTRY_AUTH_FILE=${docker_config}

--- a/scripts/skopeo-copy.sh
+++ b/scripts/skopeo-copy.sh
@@ -6,6 +6,9 @@ set -eu -o pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/skopeo-common.sh"
 
+# Ensure the /tekton/home/.docker directory exists
+mkdir -p /tekton/home/.docker
+
 phase "Copying '${PARAMS_SOURCE_IMAGE_URL}' into '${PARAMS_DESTINATION_IMAGE_URL}'"
 
 set -x

--- a/templates/task-skopeo-copy.yaml
+++ b/templates/task-skopeo-copy.yaml
@@ -61,6 +61,8 @@ spec:
   volumes:
     - name: scripts-dir
       emptyDir: {}
+    - name: tekton-home
+      emptyDir: {}
 
   stepTemplate:
     env:
@@ -79,9 +81,14 @@ spec:
 
   steps:
     - name: skopeo-copy
+      env:
+        - name: HOME
+          value: /tekton/home
       image: {{ .Values.images.skopeo }}
       script: |
 {{- include "load_scripts" ( list . ( list "skopeo-" ) ( list "/scripts/skopeo-copy.sh" "/scripts/skopeo-results.sh" ) ) | nindent 8 }}
       volumeMounts:
         - name: scripts-dir
           mountPath: /scripts
+        - name: tekton-home
+          mountPath: /tekton/home

--- a/values.yaml
+++ b/values.yaml
@@ -2,8 +2,8 @@
 # task steps container images
 images:
   bash: registry.access.redhat.com/ubi8-minimal:8.9
-  skopeo: registry.access.redhat.com/ubi8/skopeo:8.9
-  buildah: registry.access.redhat.com/ubi8/buildah:8.9
+  skopeo: registry.access.redhat.com/ubi8/skopeo:8.10-5
+  buildah: registry.access.redhat.com/ubi8/buildah:8.10-5
   s2i: registry.access.redhat.com/source-to-image/source-to-image-rhel8:v1.3.9-6
 
 # source-to-image builder images, each language represents a distinct ecosystem the builder supports,


### PR DESCRIPTION
With reference to the JIRA issue https://issues.redhat.com/browse/SRVKP-5894, where skopeo-copy was failing with the error "unauthorized: access to the requested resource is not authorized while writing manifest".  
The issue is caused by the skopeo task attempting to create a directory at the root of the container's filesystem (/.docker), which is typically restricted due to permission issues hence the destination for the credentials (.docker directory) is set to a writable path within the container's filesystem, such as a directory within the /tekton/home.

Signed off by @Senjuti256 <sde@redhat.com>