### PR TITLE
[SRVKP-5563] Fixed issue with VERBOSE=False for skopeo-copy

### DIFF
--- a/scripts/skopeo-copy.sh
+++ b/scripts/skopeo-copy.sh
@@ -14,7 +14,7 @@ phase "Copying '${PARAMS_SOURCE_IMAGE_URL}' into '${PARAMS_DESTINATION_IMAGE_URL
 set -x
 
 if [ -n "${PARAMS_SOURCE_IMAGE_URL}" ] && [ -n "${PARAMS_DESTINATION_IMAGE_URL}" ]; then
-    skopeo copy "${SKOPEO_DEBUG_FLAG}" \
+    skopeo copy ${SKOPEO_DEBUG_FLAG} \
         --src-tls-verify="${PARAMS_SRC_TLS_VERIFY}" \
         --dest-tls-verify="${PARAMS_DEST_TLS_VERIFY}" \
         "${PARAMS_SOURCE_IMAGE_URL}" \


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVKP-5563

The issue still persisted due to an extra "" remaining in the command when calling skopeo-copy, fixed it now.