### PR TITLE
remove BUILD_ARGS as BUILD_EXTRA_ARGS does the similar functionality

### DIFF
--- a/scripts/buildah-bud.sh
+++ b/scripts/buildah-bud.sh
@@ -34,12 +34,6 @@ phase "Inspecting context '${PARAMS_CONTEXT}'"
 [[ ! -d "${PARAMS_CONTEXT}" ]] &&
     fail "CONTEXT param is not found at '${PARAMS_CONTEXT}', on source workspace"
 
-phase "Building build args"
-BUILD_ARGS=()
-for buildarg in "$@"; do
-    BUILD_ARGS+=("--build-arg=$buildarg")
-done
-
 # Handle optional dockerconfig secret
 if [[ "${WORKSPACES_DOCKERCONFIG_BOUND}" == "true" ]]; then
 
@@ -79,7 +73,6 @@ phase "Building '${PARAMS_IMAGE}' based on '${DOCKERFILE_FULL}'"
 
 _buildah bud ${PARAMS_BUILD_EXTRA_ARGS} \
     $ENTITLEMENT_VOLUME \
-    "${BUILD_ARGS[@]}" \
     --file="${DOCKERFILE_FULL}" \
     --tag="${PARAMS_IMAGE}" \
     "${PARAMS_CONTEXT}"

--- a/templates/task-buildah.yaml
+++ b/templates/task-buildah.yaml
@@ -44,12 +44,6 @@ spec:
       default: ./Dockerfile
       description: |
         Path to the `Dockerfile` (or `Containerfile`) relative to the `source` workspace.
-    - name: BUILD_ARGS
-      type: array
-      default:
-        - ""
-      description: |
-        Dockerfile build arguments, array of key=value
 
 {{- include "params_buildah_common" . | nindent 4 }}
 {{- include "params_common" . | nindent 4 }}
@@ -85,8 +79,6 @@ spec:
     - name: build
       image: {{ .Values.images.buildah }}
       workingDir: $(workspaces.source.path)
-      args:
-        - $(params.BUILD_ARGS[*])
       script: |
 {{- include "load_scripts" ( list . ( list "buildah-" ) ( list "/scripts/buildah-bud.sh" ) ) | nindent 8 }}
       securityContext:


### PR DESCRIPTION
There was no `BUILD_ARGS` in the builder clusterTasks https://github.com/tektoncd/operator/blob/release-v0.73.x/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
