### PR TITLE
fixing the location of IMAGE_SCRIPTS_URL for s2i-java task

### DIFF
--- a/templates/spec-s2i.tpl
+++ b/templates/spec-s2i.tpl
@@ -30,7 +30,7 @@ params:
     type: string
   - name: IMAGE_SCRIPTS_URL
     type: string
-    default: image:///usr/libexec/s2i         
+    default: {{ default "image:///usr/libexec/s2i" .Values.IMAGE_SCRIPTS_URL | quote }}
     description: |
       Specify a URL containing the default assemble and run scripts for the builder image
   - name: ENV_VARS

--- a/templates/task-s2i-java.yaml
+++ b/templates/task-s2i-java.yaml
@@ -1,4 +1,6 @@
 {{- $s2iBuilderImage := .Values.s2iBuilders.java -}}
+{{- /* Override the IMAGE_SCRIPTS_URL value only for s2i-java */ -}}
+{{- $_ := set .Values "IMAGE_SCRIPTS_URL" "image:///usr/local/s2i" -}}
 ---
 apiVersion: tekton.dev/v1
 kind: Task


### PR DESCRIPTION
The s2i-java task if failing due to 
STEP 7/8: RUN /usr/libexec/s2i/assemble
/bin/sh: /usr/libexec/s2i/assemble: No such file or directory
subprocess exited with status 127
subprocess exited with status 127
Error: building at STEP "RUN /usr/libexec/s2i/assemble": exit status 127

upon investigating, it looks like the default path is present at /usr/local/s2i instead of /usr/libexec/s2i

Running a container based on the s2i builder images available here:[ https://github.com/openshift-pipelines/task-containers/blob/main/docs/task-s2i.md](https://github.com/openshift-pipelines/task-containers/blob/main/docs/task-s2i.md). we get 

docker run --rm -it registry.access.redhat.com/ubi8/openjdk-11:latest bash
[jboss@d4d43fb6d6a5 ~]$ cd /usr/local/s2i/
assemble          common.sh         run               s2i-setup         save-artifacts    scl-enable-maven  usage             
[jboss@d4d43fb6d6a5 ~]$ ls /usr/local/s2i/ 
assemble  common.sh  run  s2i-setup  save-artifacts  scl-enable-maven  usage
[jboss@d4d43fb6d6a5 ~]$ 

For other s2i tasks such as go, donet etc this is not the case. For example, 
docker run --rm -it registry.access.redhat.com/ubi8/go-toolset:1.19.10-3 bash
bash-4.4$ ls -lrt /usr/libexec/s2i/assemble 
-rwxrwxr-x. 1 default root 1070 Jun 29  2023 /usr/libexec/s2i/assemble
bash-4.4$ 


