### PR TITLE
Fix: Pass script arguments in template execution

### DIFF
--- a/templates/load-scripts.tpl
+++ b/templates/load-scripts.tpl
@@ -20,6 +20,6 @@ chmod +x /scripts/{{ $prefix }}*.sh;
 
 {{- range $i, $script := index . 2 -}}
 echo "Running Script {{ $script }}";
-  {{ $script }};
+  {{ $script }} "$@";
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
This PR fixes the way scripts are executed in the generated output.
Currently, the generated command to run the buildah script does not pass along any arguments ("$@").
As a result, scripts cannot receive runtime parameters if provided.

Changes made:

Updated the template to append "$@" when invoking the script.