### PR TITLE
IMAGE_SCRIPTS_URL set for java is getting updated to tasks like Go/.N…

### DIFF
--- a/templates/task-s2i-java.yaml
+++ b/templates/task-s2i-java.yaml
@@ -18,3 +18,5 @@ spec:
     {{ $s2iBuilderImage | quote }}.
 
 {{ include "spec_s2i" ( list . $s2iBuilderImage ) | nindent 2 }}
+{{- /* now clear it so other tasks pick up the default value */ -}}
+{{- $_ := set .Values "IMAGE_SCRIPTS_URL" "" -}}


### PR DESCRIPTION
This change ensures that only the Java S2I Task uses the custom /usr/local/s2i scripts URL, and that the Go (and later .NET) tasks correctly fall back to the default /usr/libexec/s2i. Previously we were mutating the .Values.IMAGE_SCRIPTS_URL in the Java template, which then "stuck" for s2i-go and dotnet.